### PR TITLE
Updated color palette to Bitcamp's

### DIFF
--- a/app/client/stylesheets/_custom.scss
+++ b/app/client/stylesheets/_custom.scss
@@ -1,3 +1,12 @@
 // Branding overrides
 //
 // Copy variables from `_branding.scss` to this file to override default values.
+
+/** BRANDING COLORS
+ * primary (Midnight Blue): sidebar color, admitted dashboard status
+ * secondary (Flame Red): header text, submitted/confirmed/checked-in dashboard status
+ * tertiary (Medium Blue): waitlist/declined dashboard status
+ */
+$primary: #1A2E33;
+$secondary: #FF3F46;
+$tertiary: #528CA5;


### PR DESCRIPTION
Please note, the button is still purple because the Quill app uses semantic-ui for their buttons and stuff. Not sure how to override them at the moment as I cannot deploy locally due to problems.

Please test this update before merging, but I suspect it should be fine because it's just a few hex colors lol.

Theoretically, the app should now look like this:
![incomplete](https://user-images.githubusercontent.com/18043276/35492602-e027a304-047b-11e8-9343-f142fe98dc0c.jpg)
![expired](https://user-images.githubusercontent.com/18043276/35492603-e147856a-047b-11e8-9d95-55b7eee1c7c3.jpg)
